### PR TITLE
Fix NEIGHBORS directions in LayeredWorldGenerator.gd

### DIFF
--- a/godot/SpaceInfiniteGeneration/LayeredWorldGenerator.gd
+++ b/godot/SpaceInfiniteGeneration/LayeredWorldGenerator.gd
@@ -15,7 +15,7 @@ const NEIGHBORS := [
 	Vector2(0, 1),
 	Vector2(-1, 1),
 	Vector2(-1, 0),
-	Vector2(-1, 1),
+	Vector2(-1, -1),
 	Vector2(0, -1),
 	Vector2(1, -1)
 ]


### PR DESCRIPTION
Fixed a subtle bug to the NEIGHBORS array.
It was checking the top-right neighbor twice while ignoring the top-left one entirely.

**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**



**Does this PR introduce a breaking change?**



## New feature or change ##


**What is the current behavior?** 



**What is the new behavior?**



**Other information**
